### PR TITLE
Replace Floyd-Warshall with simpler approach

### DIFF
--- a/sklearn/cluster/som_.py
+++ b/sklearn/cluster/som_.py
@@ -68,19 +68,19 @@ def _get_minimum_distances(adjacency):
     adjacency : symmetric square ndarray
     Matrix with distances between pairs of graph nodes (usually 1s), or np.inf
     for no connection.
-
-    Based on the `Floyd-Warshall algorithm
-    <https://en.wikipedia.org/wiki/Floyd-Warshall_algorithm>`_.
     """
     assert (len(adjacency.shape) == 2 and adjacency.shape[0] == adjacency.shape[1]), \
         "adjacency isn't a square matrix"
     n_nodes = adjacency.shape[0]
+    side = np.sqrt(n_nodes)
     distance = adjacency.copy()
-    for k in range(n_nodes):
-        for i in range(n_nodes):
-            for j in range(n_nodes):
-                if distance[i, j] > distance[i, k] + distance[k, j]:
-                    distance[i, j] = distance[i, k] + distance[k, j]
+    for i in range(n_nodes):
+        for j in range(n_nodes):
+            x_i = i % side
+            y_i = int(i / side)
+            x_j = j % side
+            y_j = int(j / side)
+            distance[i, j] = abs(x_i - x_j) + abs(y_i - y_j)
 
     return(distance)
 


### PR DESCRIPTION
Since the only possible distance between two neighboring cells is 1 and there is no such thing as unreachable node then there is no need in Floyd-Warshall. We know the shape of the grid and we can just calculate position of each node. Then we count number of steps needed to get to that node from each other node. This reduces complexity from O(n^3) to O(n^2). In my case of SOM with side 25 (625 nodes) that was an improvement from 4 minutes to 18 seconds (total algorithm time).
